### PR TITLE
build: modernise build system and add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Git
+.git/
+.gitignore
+
+# Existing build artifacts
+libfs/build/
+libfs/bench/stat/
+bench/
+
+# Large vendored kernel source trees (not needed for userspace build)
+kernelmode/linux-3.2.2/
+kernelmode/linux-3.2.2-sankar-patch/
+kernelmode/linux-3.9/
+
+# Vendored benchmark dependencies
+bench/kyotocabinet-1.2.76/
+bench/sysbench-0.4.12/
+
+# Compiled objects / libraries (in case a partial build exists)
+**/*.o
+**/*.a
+**/*.so
+**/*.so.*
+
+# SCons artifacts
+**/.sconsign.dblite
+**/build-setup.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1
+# ---------------------------------------------------------------------------
+# Aerie – usermode NVM filesystem
+# Platform: linux/amd64 only (code uses rdtsc / SSE movnti / cpu_set_t)
+# ---------------------------------------------------------------------------
+
+# ---- stage 1: build --------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        libconfig++-dev \
+        libboost-dev \
+        libsparsehash-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /aerie
+
+# Copy only what the build needs (see .dockerignore for exclusions)
+COPY libfs/ libfs/
+
+RUN cmake -S libfs -B libfs/build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DRPC=fast \
+        -DSCMPOOL=kernel \
+    && cmake --build libfs/build --parallel "$(nproc)"
+
+
+# ---- stage 2: runtime ------------------------------------------------------
+FROM --platform=linux/amd64 ubuntu:22.04 AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libconfig++9v5 \
+        libboost-system1.74.0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Binaries
+COPY --from=builder /aerie/libfs/build/src/scm/tool/pool/pool_tool  /usr/local/bin/pool_tool
+COPY --from=builder /aerie/libfs/build/src/pxfs/pxfs_server          /usr/local/bin/pxfs_server
+COPY --from=builder /aerie/libfs/build/src/pxfs/pxfs_mkfs            /usr/local/bin/pxfs_mkfs
+COPY --from=builder /aerie/libfs/build/src/pxfs/pxfs_client          /usr/local/bin/pxfs_client
+COPY --from=builder /aerie/libfs/build/src/kvfs/kvfs_server          /usr/local/bin/kvfs_server
+COPY --from=builder /aerie/libfs/build/src/kvfs/kvfs_mkfs            /usr/local/bin/kvfs_mkfs
+COPY --from=builder /aerie/libfs/build/src/cfs/cfs_server            /usr/local/bin/cfs_server
+COPY --from=builder /aerie/libfs/build/src/cfs/cfs_mkfs              /usr/local/bin/cfs_mkfs
+COPY --from=builder /aerie/libfs/build/bench/ubench/ubench_pxfs      /usr/local/bin/ubench_pxfs
+COPY --from=builder /aerie/libfs/build/bench/ubench/ubench_vfs       /usr/local/bin/ubench_vfs
+
+# Shared libraries
+COPY --from=builder /aerie/libfs/build/ /aerie/build/
+RUN find /aerie/build -name "*.so" -exec cp {} /usr/local/lib/ \; && ldconfig
+
+# Runtime config
+COPY libfs/libfs.ini /etc/libfs.ini
+ENV LIBFS_CONF=/etc/libfs.ini
+
+# Pool lives on a named volume so it survives container restarts
+VOLUME ["/data"]
+
+COPY libfs/scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/aerie-*.sh
+
+EXPOSE 10000
+
+ENTRYPOINT ["/usr/local/bin/aerie-server.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,127 @@
-# aerie
-Usermode filesystem for NVM
+# Aerie
 
-Usermode filesystem for NVM
+A usermode filesystem for Non-Volatile Memory (NVM / Storage Class Memory).
+
+Aerie runs entirely in userspace — no kernel filesystem module required. It maps a persistent storage pool directly into process address space via `mmap` and provides POSIX filesystem semantics through a client library that communicates with a local server process over shared memory + RPC.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Application                            │
+│  (links libfsc / libc_api)              │
+└────────────────┬────────────────────────┘
+                 │ IPC (shared memory + RPC)
+┌────────────────▼────────────────────────┐
+│  pxfs_server                            │
+│  ├── OSD layer  (locking, journaling)   │
+│  ├── MFS backend (directory/file inodes)│
+│  └── SCM pool   (mmap'd persistent file)│
+└─────────────────────────────────────────┘
+```
+
+The storage pool is a regular file memory-mapped at a fixed virtual address. No kernel module or special hardware is required; SCM write latency is emulated in userspace via `movnti` + busy-spin.
+
+## Filesystem variants
+
+| Name | Description |
+|------|-------------|
+| **pxfs** | POSIX-compliant filesystem — primary variant |
+| **cfs** | Cache filesystem variant |
+| **rxfs** | Read-only / replica client |
+| **kvfs** | Key-value store filesystem |
+
+## Building
+
+### Requirements
+
+- Linux x86-64 (code uses `rdtsc`, SSE `movnti`, and `cpu_set_t`)
+- CMake ≥ 3.16
+- GCC / Clang with C++11 support
+- `libconfig++` (`libconfig++-dev` on Debian/Ubuntu)
+- Boost headers (`libboost-dev`)
+- Google Sparsehash (`libsparsehash-dev`)
+
+### Native build
+
+```bash
+cmake -S libfs -B libfs/build -DRPC=fast
+cmake --build libfs/build --parallel $(nproc)
+```
+
+**Build options:**
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `RPC` | `net`, `fast`, `fast-two` | `net` | RPC transport |
+| `SCMPOOL` | `kernel`, `user` | `kernel` | SCM pool allocator |
+| `BUILD_BENCH` | `ON`, `OFF` | `ON` | Build benchmark programs |
+| `LIBCONFIG_ROOT` | path | — | Local libconfig build root |
+| `GOOGLE_SPARSEHASH` | path | — | Sparsehash headers (if not on system path) |
+
+### Docker (recommended)
+
+Docker is the easiest way to get a working build — no need to install dependencies or worry about ASLR settings.
+
+```bash
+# Build and start the pxfs server
+docker compose up --build
+
+# Run the micro-benchmark against the running server
+docker compose --profile bench run --rm bench
+```
+
+Override defaults via environment variables:
+
+```bash
+POOL_SIZE=1024M PORT=10000 docker compose up --build
+```
+
+> **Note:** `PersistentRegion` uses `MAP_FIXED` to remap the pool at its original virtual address on restart. ASLR must be disabled (`kernel.randomize_va_space=0`). The `docker-compose.yml` sets this automatically via `sysctls`.
+
+## Running manually
+
+```bash
+BUILD=libfs/build
+
+# 1. Create storage pool
+$BUILD/src/scm/tool/pool/pool_tool create -p /tmp/stamnos_pool -s 512M
+
+# 2. Format the filesystem
+$BUILD/src/pxfs/pxfs_mkfs create -p /tmp/stamnos_pool -s 512M -t mfs
+
+# 3. Start the server (background)
+$BUILD/src/pxfs/pxfs_server -p 10000 -d 0 -s /tmp/stamnos_pool &
+
+# 4. Run a benchmark
+$BUILD/bench/ubench/ubench_pxfs -h 10000 -d 0 +fs_create -p /pxfs/ -n 1000 -s 4096
+```
+
+Configuration is read from `libfs/libfs.ini` (or the path in `$LIBFS_CONF`).
+
+## Repository layout
+
+```
+libfs/                  Userspace filesystem library
+  src/
+    bcs/                Basic Communication Services (RPC + IPC)
+    scm/                SCM abstraction (persistent regions, pool allocator)
+    osd/                Object Storage Device layer (locking, journaling)
+    pxfs/               POSIX filesystem (server + client + mkfs tool)
+    cfs/                Cache filesystem variant
+    rxfs/               Read-only client variant
+    kvfs/               Key-value store variant
+    common/             Shared utilities
+  bench/                Micro-benchmarks
+  scripts/              Docker entrypoint scripts
+kernelmode/
+  scmdisk/              Optional Linux kernel block device that emulates
+                        SCM latency at the block layer (not required for
+                        the userspace filesystem)
+```
+
+## Dependencies
+
+- [libconfig++](http://hyperrealm.github.io/libconfig/)
+- [Boost C++ Libraries](https://www.boost.org/)
+- [Google Sparsehash](https://github.com/sparsehash/sparsehash)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------
+# Aerie docker-compose
+#
+# Usage:
+#   docker compose up --build          # build + start server
+#   docker compose run bench           # run micro-benchmark against server
+#   docker compose run --rm bench \
+#     bash -c "BENCH_OPS='+fs_create +fs_read' aerie-bench.sh"
+#
+# ASLR note:
+#   PersistentRegion uses MAP_FIXED; ASLR must be disabled.
+#   The sysctl below requires Docker to be run with sufficient privilege
+#   (works by default on Linux; on macOS/Docker Desktop it is a no-op
+#   because the Linux VM already has ASLR disabled).
+# ---------------------------------------------------------------------------
+
+services:
+  server:
+    build:
+      context: .
+      target: runtime
+    platform: linux/amd64
+    image: aerie:latest
+    # Disable ASLR for MAP_FIXED remapping of persistent regions
+    sysctls:
+      kernel.randomize_va_space: 0
+    # Give shared-memory room for IPC buffers
+    shm_size: 256m
+    volumes:
+      - pool-data:/data
+      - ./libfs/libfs.ini:/etc/libfs.ini:ro
+    ports:
+      - "10000:10000"
+    environment:
+      POOL_PATH: /data/stamnos_pool
+      POOL_SIZE: 512M
+      PORT: "10000"
+      DEBUG: "0"
+    restart: unless-stopped
+
+  bench:
+    image: aerie:latest
+    platform: linux/amd64
+    sysctls:
+      kernel.randomize_va_space: 0
+    shm_size: 256m
+    depends_on:
+      - server
+    entrypoint: /usr/local/bin/aerie-bench.sh
+    environment:
+      SERVER_HOST: server
+      PORT: "10000"
+      BENCH_OPS: +fs_create
+      BENCH_PATH: /pxfs
+      BENCH_N: "1000"
+      BENCH_SIZE: "4096"
+    profiles:
+      - bench    # only starts with: docker compose --profile bench up
+
+volumes:
+  pool-data:

--- a/libfs/CMakeLists.txt
+++ b/libfs/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.16)
+project(aerie LANGUAGES C CXX)
+
+# Use uppercase <PACKAGENAME>_ROOT variables (CMake 3.27+)
+cmake_policy(SET CMP0144 NEW)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ---------------------------------------------------------------------------
+# Build options  (override on command line: cmake -DRPC=fast -B build)
+# ---------------------------------------------------------------------------
+option(BUILD_BENCH "Build benchmark programs" ON)
+
+set(RPC "net" CACHE STRING "RPC backend: net | fast | fast-two")
+set_property(CACHE RPC PROPERTY STRINGS net fast fast-two)
+
+set(SCMPOOL "kernel" CACHE STRING "SCM pool implementation: kernel | user")
+set_property(CACHE SCMPOOL PROPERTY STRINGS kernel user)
+
+set(GOOGLE_SPARSEHASH "" CACHE PATH "Path to google-sparsehash headers (if not on system include path)")
+set(LIBCONFIG_ROOT    "" CACHE PATH "Root of a locally-built libconfig source tree (optional; uses system install by default)")
+set(LIBHOARD          "" CACHE PATH "Path to libhoard directory (optional)")
+
+# ---------------------------------------------------------------------------
+# Compiler flags
+# ---------------------------------------------------------------------------
+add_compile_options(-O2)
+add_compile_definitions(__STDC_FORMAT_MACROS)
+
+# RPC mode
+if(RPC STREQUAL "fast")
+    add_compile_definitions(_CLT2SVR_RPCFAST _SVR2CLT_RPCNET)
+elseif(RPC STREQUAL "fast-two")
+    add_compile_definitions(_CLT2SVR_RPCFAST _SVR2CLT_RPCFAST)
+else()                          # net (default)
+    add_compile_definitions(_CLT2SVR_RPCNET _SVR2CLT_RPCNET)
+endif()
+
+# SCM pool mode
+if(SCMPOOL STREQUAL "user")
+    add_compile_definitions(_SCM_POOL_USERMODE)
+else()
+    add_compile_definitions(_SCM_POOL_KERNELMODE)
+endif()
+
+add_compile_definitions(KVFS_USE_INDIRECT)
+
+# ---------------------------------------------------------------------------
+# Platform libs (rt merged into glibc on modern Linux, but harmless to list)
+# ---------------------------------------------------------------------------
+if(UNIX AND NOT APPLE)
+    set(RT_LIB rt)
+endif()
+
+# ---------------------------------------------------------------------------
+# External dependencies
+# ---------------------------------------------------------------------------
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+find_package(LibConfig REQUIRED)
+
+if(GOOGLE_SPARSEHASH)
+    include_directories(${GOOGLE_SPARSEHASH})
+endif()
+
+if(LIBHOARD)
+    link_directories(${LIBHOARD})
+    add_link_options(-lhoard)
+endif()
+
+# ---------------------------------------------------------------------------
+# Common INTERFACE target — provides the src/ include root AND libconfig
+# headers to every target in the project.  libconfig.h is transitively
+# pulled in by cdebug.h → rtcconfig.h so all targets need it, not just bcs.
+# ---------------------------------------------------------------------------
+add_library(aerie_includes INTERFACE)
+target_include_directories(aerie_includes INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(aerie_includes INTERFACE
+    LibConfig::LibConfig
+    LibConfig::LibConfigPP
+)
+
+# ---------------------------------------------------------------------------
+# Subdirectories
+# ---------------------------------------------------------------------------
+add_subdirectory(src)
+
+if(BUILD_BENCH)
+    add_subdirectory(bench)
+endif()

--- a/libfs/bench/CMakeLists.txt
+++ b/libfs/bench/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_subdirectory(ubench)
+
+# sharing bench (VFS-only, no libfs dependency)
+add_executable(sharing_vfs
+    sharing/main.cc
+    sharing/create-vfs.cc
+    sharing/open-vfs.cc
+    sharing/barrier.cc
+)
+target_include_directories(sharing_vfs PRIVATE
+    ${CMAKE_SOURCE_DIR}/bench
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
+)
+target_link_libraries(sharing_vfs PRIVATE Threads::Threads ${RT_LIB})

--- a/libfs/bench/ubench/CMakeLists.txt
+++ b/libfs/bench/ubench/CMakeLists.txt
@@ -1,0 +1,81 @@
+# ---------------------------------------------------------------------------
+# ubench – micro-benchmark programs
+# ---------------------------------------------------------------------------
+
+set(bench_incdirs
+    ${CMAKE_SOURCE_DIR}/bench
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
+)
+
+# Per-filesystem client dependency sets
+set(osd_libs   mfsclt fsc bcsclt osdclt scm common Threads::Threads ${RT_LIB})
+set(pxfs_libs  mfsclt fsc bcsclt osdclt scm common Threads::Threads ${RT_LIB})
+set(cfs_libs   cfsc       bcsclt osdclt scm common Threads::Threads ${RT_LIB})
+set(rxfs_libs  rxfsc      bcsclt osdclt scm common Threads::Threads ${RT_LIB})
+
+# FS benchmark common sources (shared across all FS flavours)
+set(fs_common
+    fs/open.cc fs/create.cc fs/unlink.cc fs/read.cc fs/fs.cc
+    fs/fread.cc fs/seqread.cc fs/randread.cc fs/seqwrite.cc
+    fs/randwrite.cc fs/delete.cc fs/append.cc fs/rename.cc
+)
+
+# OSD-level benchmark objects
+set(osd_sources
+    osd/create.cc osd/open.cc osd/lock.cc osd/hlock.cc osd/rpc.cc osd/osd.cc
+)
+
+# ---------------------------------------------------------------------------
+# ubench_osd
+# ---------------------------------------------------------------------------
+add_executable(ubench_osd main.cc ${osd_sources})
+target_include_directories(ubench_osd PRIVATE ${bench_incdirs})
+target_link_libraries(ubench_osd PRIVATE ${osd_libs})
+
+# ---------------------------------------------------------------------------
+# ubench_vfs  (plain POSIX, no libfs)
+# ---------------------------------------------------------------------------
+add_executable(ubench_vfs main.cc ${fs_common} fs/vfs.cc)
+target_include_directories(ubench_vfs PRIVATE ${bench_incdirs})
+target_link_libraries(ubench_vfs PRIVATE Threads::Threads ${RT_LIB})
+
+# ---------------------------------------------------------------------------
+# ubench_pxfs
+# ---------------------------------------------------------------------------
+add_executable(ubench_pxfs main.cc ${fs_common} fs/pxfs.cc)
+target_include_directories(ubench_pxfs PRIVATE ${bench_incdirs})
+target_link_libraries(ubench_pxfs PRIVATE ${pxfs_libs})
+
+# ---------------------------------------------------------------------------
+# ubench_cfs
+# ---------------------------------------------------------------------------
+add_executable(ubench_cfs main.cc ${fs_common} fs/cfs.cc)
+target_include_directories(ubench_cfs PRIVATE ${bench_incdirs})
+target_link_libraries(ubench_cfs PRIVATE ${cfs_libs})
+
+# ---------------------------------------------------------------------------
+# ubench_rxfs
+# ---------------------------------------------------------------------------
+add_executable(ubench_rxfs main.cc ${fs_common} fs/rxfs.cc)
+target_include_directories(ubench_rxfs PRIVATE ${bench_incdirs})
+target_link_libraries(ubench_rxfs PRIVATE ${rxfs_libs})
+
+# ---------------------------------------------------------------------------
+# Multi-client programs
+# ---------------------------------------------------------------------------
+add_executable(clt01 clt01.cc ${fs_common} fs/pxfs.cc)
+target_include_directories(clt01 PRIVATE ${bench_incdirs})
+target_link_libraries(clt01 PRIVATE ${pxfs_libs})
+
+add_executable(clt02 clt02.cc ${fs_common} fs/pxfs.cc)
+target_include_directories(clt02 PRIVATE ${bench_incdirs})
+target_link_libraries(clt02 PRIVATE ${pxfs_libs})
+
+add_executable(clt03 clt03.cc)
+target_include_directories(clt03 PRIVATE ${bench_incdirs})
+target_link_libraries(clt03 PRIVATE Threads::Threads ${RT_LIB})
+
+add_executable(bench_read read.cc ${fs_common} fs/pxfs.cc)
+target_include_directories(bench_read PRIVATE ${bench_incdirs})
+target_link_libraries(bench_read PRIVATE ${pxfs_libs})

--- a/libfs/cmake/FindLibConfig.cmake
+++ b/libfs/cmake/FindLibConfig.cmake
@@ -1,0 +1,56 @@
+# FindLibConfig.cmake
+#
+# Finds libconfig and libconfig++.
+# If LIBCONFIG_ROOT is set, searches there first (for locally-built source trees
+# where the .libs/ sub-directory holds the built shared objects).
+#
+# Imported targets created:
+#   LibConfig::LibConfig    – the C library  (-lconfig)
+#   LibConfig::LibConfigPP  – the C++ library (-lconfig++)
+#
+# Also sets:
+#   LibConfig_FOUND
+#   LIBCONFIG_INCLUDE_DIR
+#   LIBCONFIG_LIBRARY
+#   LIBCONFIGPP_LIBRARY
+
+find_path(LIBCONFIG_INCLUDE_DIR
+    NAMES libconfig.h libconfig.hh
+    HINTS ${LIBCONFIG_ROOT}
+    PATH_SUFFIXES include
+)
+
+find_library(LIBCONFIG_LIBRARY
+    NAMES config
+    HINTS ${LIBCONFIG_ROOT}
+    PATH_SUFFIXES .libs lib lib64
+)
+
+find_library(LIBCONFIGPP_LIBRARY
+    NAMES config++
+    HINTS ${LIBCONFIG_ROOT}
+    PATH_SUFFIXES .libs lib lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibConfig
+    REQUIRED_VARS LIBCONFIG_LIBRARY LIBCONFIGPP_LIBRARY LIBCONFIG_INCLUDE_DIR
+)
+
+if(LibConfig_FOUND)
+    if(NOT TARGET LibConfig::LibConfig)
+        add_library(LibConfig::LibConfig UNKNOWN IMPORTED)
+        set_target_properties(LibConfig::LibConfig PROPERTIES
+            IMPORTED_LOCATION             "${LIBCONFIG_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBCONFIG_INCLUDE_DIR}"
+        )
+    endif()
+
+    if(NOT TARGET LibConfig::LibConfigPP)
+        add_library(LibConfig::LibConfigPP UNKNOWN IMPORTED)
+        set_target_properties(LibConfig::LibConfigPP PROPERTIES
+            IMPORTED_LOCATION             "${LIBCONFIGPP_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBCONFIG_INCLUDE_DIR}"
+        )
+    endif()
+endif()

--- a/libfs/scripts/aerie-bench.sh
+++ b/libfs/scripts/aerie-bench.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# aerie-bench.sh  –  run the pxfs micro-benchmark against a running server
+#
+# Environment variables:
+#   SERVER_HOST   server hostname / IP   (default: server)
+#   PORT          server port            (default: 10000)
+#   BENCH_OPS     benchmark operations   (default: +fs_create)
+#   BENCH_PATH    filesystem path prefix (default: /pxfs)
+#   BENCH_N       number of ops          (default: 1000)
+#   BENCH_SIZE    per-file size (bytes)  (default: 4096)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SERVER_HOST="${SERVER_HOST:-server}"
+PORT="${PORT:-10000}"
+BENCH_OPS="${BENCH_OPS:-+fs_create}"
+BENCH_PATH="${BENCH_PATH:-/pxfs}"
+BENCH_N="${BENCH_N:-1000}"
+BENCH_SIZE="${BENCH_SIZE:-4096}"
+
+exec ubench_pxfs \
+    -h "${PORT}" \
+    -d 0 \
+    "${BENCH_OPS}" \
+    -p "${BENCH_PATH}" \
+    -n "${BENCH_N}" \
+    -s "${BENCH_SIZE}"

--- a/libfs/scripts/aerie-server.sh
+++ b/libfs/scripts/aerie-server.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# aerie-server.sh  –  initialise storage pool (if needed) and start pxfs_server
+#
+# Environment variables:
+#   POOL_PATH   path to the pool file           (default: /data/stamnos_pool)
+#   POOL_SIZE   pool size passed to pool_tool   (default: 512M)
+#   FS_TYPE     filesystem type for mkfs        (default: mfs)
+#   PORT        server TCP port                 (default: 10000)
+#   DEBUG       debug level 0-5                 (default: 0)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+POOL_PATH="${POOL_PATH:-/data/stamnos_pool}"
+POOL_SIZE="${POOL_SIZE:-512M}"
+FS_TYPE="${FS_TYPE:-mfs}"
+PORT="${PORT:-10000}"
+DEBUG="${DEBUG:-0}"
+
+# Disable ASLR — PersistentRegion uses MAP_FIXED and stores the mapped base
+# address in the pool header; remapping fails if the address shifts.
+if [ -w /proc/sys/kernel/randomize_va_space ]; then
+    echo 0 > /proc/sys/kernel/randomize_va_space
+else
+    echo "WARNING: cannot disable ASLR (no write access to /proc/sys/kernel/randomize_va_space)" >&2
+    echo "         Run the container with --sysctl kernel.randomize_va_space=0" >&2
+fi
+
+# Clean up any leftover shared buffers from a previous run
+rm -f /tmp/shbuf_*
+
+# Create pool + filesystem on first run
+if [ ! -f "${POOL_PATH}" ]; then
+    echo "==> Creating storage pool at ${POOL_PATH} (${POOL_SIZE})"
+    pool_tool create -p "${POOL_PATH}" -s "${POOL_SIZE}"
+
+    echo "==> Formatting filesystem (type: ${FS_TYPE})"
+    pxfs_mkfs create -p "${POOL_PATH}" -s "${POOL_SIZE}" -t "${FS_TYPE}"
+fi
+
+echo "==> Starting pxfs_server on port ${PORT}"
+exec pxfs_server -p "${PORT}" -d "${DEBUG}" -s "${POOL_PATH}"

--- a/libfs/src/CMakeLists.txt
+++ b/libfs/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_subdirectory(bcs)
+add_subdirectory(scm)
+add_subdirectory(common)
+add_subdirectory(osd)
+add_subdirectory(pxfs)
+add_subdirectory(cfs)
+add_subdirectory(rxfs)
+add_subdirectory(kvfs)

--- a/libfs/src/bcs/CMakeLists.txt
+++ b/libfs/src/bcs/CMakeLists.txt
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------------------
+# BCS – Basic Communication Services
+#
+# Layer order:
+#   rpcnet / rpcfast        raw RPC transports
+#   bcs_common (OBJECT)     shared debug/config objects compiled once
+#   bcsclt                  client-side IPC
+#   bcssrv                  server-side IPC
+# ---------------------------------------------------------------------------
+
+# ---------- rpc-net ---------------------------------------------------------
+add_library(rpcnet SHARED
+    backend/rpc-net/rpc.cc
+    backend/rpc-net/connection.cc
+    backend/rpc-net/pollmgr.cc
+    backend/rpc-net/thr_pool.cc
+    backend/rpc-net/jsl_log.cc
+)
+target_link_libraries(rpcnet PUBLIC aerie_includes Threads::Threads)
+
+# ---------- rpc-fast --------------------------------------------------------
+add_library(rpcfast SHARED
+    backend/rpc-fast/rpc.cc
+)
+target_link_libraries(rpcfast PUBLIC aerie_includes Threads::Threads)
+
+# ---------- bcs common (compiled once, linked into both clt and srv) --------
+add_library(bcs_common OBJECT
+    main/common/rtconfig.cc
+    main/common/debug.cc
+    main/common/cdebug.c
+    main/common/rtcconfig.c
+)
+target_link_libraries(bcs_common PUBLIC aerie_includes)
+
+# ---------- bcsclt ----------------------------------------------------------
+add_library(bcsclt SHARED
+    main/client/ipc.cc
+    main/client/shbuf.cc
+    $<TARGET_OBJECTS:bcs_common>
+)
+target_link_libraries(bcsclt PUBLIC aerie_includes rpcnet rpcfast)
+
+# ---------- bcssrv ----------------------------------------------------------
+add_library(bcssrv SHARED
+    main/server/cltdsc.cc
+    main/server/ipc.cc
+    main/server/sessionmgr.cc
+    main/server/session.cc
+    main/server/shbuf.cc
+    main/server/shbufmgr.cc
+    $<TARGET_OBJECTS:bcs_common>
+)
+target_link_libraries(bcssrv PUBLIC aerie_includes rpcnet rpcfast)

--- a/libfs/src/cfs/CMakeLists.txt
+++ b/libfs/src/cfs/CMakeLists.txt
@@ -1,0 +1,37 @@
+# ---------------------------------------------------------------------------
+# cfs – Cache filesystem
+# ---------------------------------------------------------------------------
+
+# ---------- cfsc (client library) -------------------------------------------
+add_library(cfsc SHARED
+    client/c_api.cc
+    client/client.cc
+    client/file.cc
+)
+target_link_libraries(cfsc PUBLIC aerie_includes osdclt bcsclt scm common)
+
+# ---------- cfss (server library) -------------------------------------------
+add_library(cfss SHARED
+    server/dir_inode.cc
+    server/fs.cc
+    server/namespace.cc
+    server/server.cc
+    server/session.cc
+)
+target_link_libraries(cfss PUBLIC aerie_includes osdsrv bcssrv scm common)
+
+# ---------- cfs_server ------------------------------------------------------
+add_executable(cfs_server server/main.cc)
+target_link_libraries(cfs_server PRIVATE cfss bcssrv osdsrv scm common Threads::Threads ${RT_LIB})
+
+# ---------- cfs_client (debug/test client) ----------------------------------
+add_executable(cfs_client client/main.cc)
+target_link_libraries(cfs_client PRIVATE cfsc bcsclt osdclt scm common Threads::Threads ${RT_LIB})
+
+# ---------- cfs_mkfs --------------------------------------------------------
+# Note: the mkfs tool also depends on mfssrv (same as pxfs_mkfs)
+add_executable(cfs_mkfs
+    tool/main.cc
+    tool/mkfs.cc
+)
+target_link_libraries(cfs_mkfs PRIVATE cfss bcssrv osdsrv mfssrv scm common Threads::Threads ${RT_LIB})

--- a/libfs/src/common/CMakeLists.txt
+++ b/libfs/src/common/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(common SHARED
+    hash.c
+    interval_tree.cc
+)
+target_link_libraries(common PUBLIC aerie_includes)

--- a/libfs/src/kvfs/CMakeLists.txt
+++ b/libfs/src/kvfs/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ---------------------------------------------------------------------------
+# kvfs – Key-value store filesystem
+# ---------------------------------------------------------------------------
+
+# ---------- kvfsc (client library) ------------------------------------------
+add_library(kvfsc SHARED
+    client/c_api.cc
+    client/client.cc
+    client/sb.cc
+    client/table.cc
+)
+target_link_libraries(kvfsc PUBLIC aerie_includes osdclt bcsclt scm common)
+
+# ---------- kvfss (server library) ------------------------------------------
+add_library(kvfss SHARED
+    server/fs.cc
+    server/publisher.cc
+    server/server.cc
+    server/session.cc
+    server/subtable.cc
+)
+target_link_libraries(kvfss PUBLIC aerie_includes osdsrv bcssrv scm common)
+
+# ---------- kvfs_server -----------------------------------------------------
+add_executable(kvfs_server server/main.cc)
+target_link_libraries(kvfs_server PRIVATE kvfss bcssrv osdsrv scm common Threads::Threads ${RT_LIB})
+
+# ---------- kvfs_mkfs -------------------------------------------------------
+add_executable(kvfs_mkfs
+    tool/main.cc
+    tool/mkfs.cc
+)
+target_link_libraries(kvfs_mkfs PRIVATE kvfss bcssrv osdsrv scm common Threads::Threads ${RT_LIB})

--- a/libfs/src/osd/CMakeLists.txt
+++ b/libfs/src/osd/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ---------------------------------------------------------------------------
+# OSD – Object Storage Device layer
+# ---------------------------------------------------------------------------
+
+# ---------- osdclt ----------------------------------------------------------
+add_library(osdclt SHARED
+    main/client/journal.cc
+    main/client/hlckmgr.cc
+    main/client/lckmgr.cc
+    main/client/omgr.cc
+    main/client/salloc.cc
+    main/client/stm.cc
+    main/client/stsystem.cc
+    main/client/registry.cc
+    containers/name/container-client.cc
+    containers/super/container.cc
+    containers/byte/container.cc
+    containers/needle/container.cc
+)
+target_link_libraries(osdclt PUBLIC aerie_includes)
+
+# ---------- osdsrv ----------------------------------------------------------
+add_library(osdsrv SHARED
+    main/server/journal.cc
+    main/server/hlckmgr.cc
+    main/server/lckmgr.cc
+    main/server/publisher.cc
+    main/server/registry.cc
+    main/server/salloc.cc
+    main/server/shbuf.cc
+    main/server/session.cc
+    main/server/verifier.cc
+    containers/name/container-server.cc
+)
+target_link_libraries(osdsrv PUBLIC aerie_includes)

--- a/libfs/src/pxfs/CMakeLists.txt
+++ b/libfs/src/pxfs/CMakeLists.txt
@@ -1,0 +1,62 @@
+# ---------------------------------------------------------------------------
+# pxfs – POSIX-compliant filesystem
+#
+# Dependency graph (bottom → top):
+#   mfsclt / mfssrv   metadata filesystem backend
+#   fsc               client library
+#   fss               server library
+#   pxfs_server / pxfs_client / pxfs_mkfs   executables
+# ---------------------------------------------------------------------------
+
+# ---------- mfsclt ----------------------------------------------------------
+add_library(mfsclt SHARED
+    mfs/client/dir_inode.cc
+    mfs/client/file_inode.cc
+    mfs/client/inode_factory.cc
+    mfs/client/mfs.cc
+    mfs/client/sb_factory.cc
+)
+target_link_libraries(mfsclt PUBLIC aerie_includes)
+
+# ---------- mfssrv ----------------------------------------------------------
+add_library(mfssrv SHARED
+    mfs/server/dir_inode.cc
+    mfs/server/mfs.cc
+    mfs/server/publisher.cc
+)
+target_link_libraries(mfssrv PUBLIC aerie_includes)
+
+# ---------- fsc (pxfs client library) ---------------------------------------
+add_library(fsc SHARED
+    client/c_api.cc
+    client/client.cc
+    client/file.cc
+    client/fsomgr.cc
+    client/inode.cc
+    client/mpinode.cc
+    client/namespace.cc
+)
+target_link_libraries(fsc PUBLIC aerie_includes mfsclt osdclt bcsclt scm common)
+
+# ---------- fss (pxfs server library) ---------------------------------------
+add_library(fss SHARED
+    server/fs.cc
+    server/server.cc
+    server/session.cc
+)
+target_link_libraries(fss PUBLIC aerie_includes osdsrv bcssrv mfssrv scm common)
+
+# ---------- pxfs_server -----------------------------------------------------
+add_executable(pxfs_server server/main.cc)
+target_link_libraries(pxfs_server PRIVATE fss bcssrv osdsrv mfssrv scm common Threads::Threads ${RT_LIB})
+
+# ---------- pxfs_client (debug/test client) ---------------------------------
+add_executable(pxfs_client client/main.cc)
+target_link_libraries(pxfs_client PRIVATE fsc mfsclt bcsclt osdclt scm common Threads::Threads ${RT_LIB})
+
+# ---------- pxfs_mkfs (filesystem formatting tool) --------------------------
+add_executable(pxfs_mkfs
+    tool/main.cc
+    tool/mkfs.cc
+)
+target_link_libraries(pxfs_mkfs PRIVATE fss bcssrv osdsrv mfssrv scm common Threads::Threads ${RT_LIB})

--- a/libfs/src/rxfs/CMakeLists.txt
+++ b/libfs/src/rxfs/CMakeLists.txt
@@ -1,0 +1,12 @@
+# ---------------------------------------------------------------------------
+# rxfs – Read-only / replica filesystem  (client-side only)
+# ---------------------------------------------------------------------------
+
+add_library(rxfsc SHARED
+    client/c_api.cc
+    client/client.cc
+    client/dir_inode.cc
+    client/file.cc
+    client/namespace.cc
+)
+target_link_libraries(rxfsc PUBLIC aerie_includes osdclt bcsclt scm common)

--- a/libfs/src/scm/CMakeLists.txt
+++ b/libfs/src/scm/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ---------------------------------------------------------------------------
+# SCM – Storage Class Memory abstraction
+#
+# Pool backend is selected at configure time via -DSCMPOOL=kernel|user.
+# The compile definition (_SCM_POOL_KERNELMODE / _SCM_POOL_USERMODE) is
+# set globally in the root CMakeLists.txt.
+# ---------------------------------------------------------------------------
+
+set(scm_core_sources
+    scm/model.cc
+    scm/memcpy.cc
+    pregion/pregion.cc
+    pheap/pheap.cc
+    pheap/vistaheap.c
+)
+
+if(SCMPOOL STREQUAL "user")
+    set(pool_sources pool/user/pool.cc)
+else()                          # kernel (default)
+    set(pool_sources
+        pool/kernel/pool-vistaheap.cc
+        pool/kernel/buddy.cc
+    )
+endif()
+
+add_library(scm SHARED ${scm_core_sources} ${pool_sources})
+target_link_libraries(scm PUBLIC aerie_includes Threads::Threads)
+
+# ---------------------------------------------------------------------------
+# pool_tool – offline storage-pool creation/inspection utility
+# ---------------------------------------------------------------------------
+add_executable(pool_tool
+    tool/pool/main.cc
+    tool/pool/mkpool.cc
+)
+target_link_libraries(pool_tool PRIVATE scm Threads::Threads)


### PR DESCRIPTION
## Summary

- **Replace SCons with CMake** — 13 `CMakeLists.txt` files covering all filesystem variants (pxfs, cfs, rxfs, kvfs) and benchmarks. Fixes a silent binary name collision where pxfs and kvfs servers both output as `fsserver`; they are now `pxfs_server` and `kvfs_server`.
- **Add Docker support** — multi-stage `Dockerfile` (builder → slim runtime), `docker-compose.yml` modelling the server + bench workflow, and updated startup scripts replacing the old hardcoded `/scratch/nvm/...` paths.
- **Rewrite README** — architecture overview, build instructions (native + Docker), manual run steps, repo layout.

## Build options

```
-DRPC=net|fast|fast-two   (default: net)
-DSCMPOOL=kernel|user     (default: kernel)
-DBUILD_BENCH=ON|OFF      (default: ON)
-DLIBCONFIG_ROOT=<path>   (for locally-built libconfig)
```

## Usage

```bash
# Native
cmake -S libfs -B libfs/build -DRPC=fast
cmake --build libfs/build --parallel $(nproc)

# Docker
docker compose up --build
docker compose --profile bench run --rm bench
```

## Notes

- The SConscript files are left in place and can be deleted once the CMake build is verified on Linux x86-64.
- `kernel.randomize_va_space=0` is required at runtime (`PersistentRegion` uses `MAP_FIXED`); `docker-compose.yml` sets this automatically via `sysctls`.