### PR TITLE
Fix ObjectIdArray type error in kvfs/client/table.cc

### DIFF
--- a/libfs/src/kvfs/client/table.cc
+++ b/libfs/src/kvfs/client/table.cc
@@ -22,7 +22,7 @@ Table::Load(::client::Session* session,
 	osd::common::ObjectProxyReference* ref;
 	Table*                             tp;
         ::osd::common::ObjectId            name_oid;
-	ObjectIdArray::Object*             array_obj;
+	ObjectIdArray*                     array_obj;
 	
 	tp = new Table();
 


### PR DESCRIPTION
ObjectIdArray is already a typedef for ArrayContainer<ObjectId>::Object, so ObjectIdArray::Object* was a double-nested invalid type. Changed to ObjectIdArray* to match the actual typedef.